### PR TITLE
Fix SpikeBand logic

### DIFF
--- a/worlds/deltarune/cross_chapter/Rules.py
+++ b/worlds/deltarune/cross_chapter/Rules.py
@@ -47,7 +47,7 @@ def set_rules(world: "DeltaruneWorld"):
             if world.include_chapter(4):  # Chapter 4 have GlowWist have starter item so don't require it
                 set_rule(
                     multiworld.get_location(CCLocations.castle_town_spike_band_fusion, player),
-                    lambda state: state.has(Ch1Items.ironshackle, player),
+                    lambda state: state.has(Ch1Items.ironshackle, player) and state.has(Ch4Items.chapter_4_unlock, player),
                 )
             elif world.include_chapter(2):  # Chapter 2 have to gain GlowWist so require it to acquire it
                 set_rule(


### PR DESCRIPTION
Currently playing an ap where my chapter 3 is locked behind spikeband and i only have ch1 and ch2 unlocked, all chapters are randomized in my rules, and my only remaining non-glitched check is spike band, which since ch4 is included (despite not being unlocked), is in logic.  

As this is a softlock outside of hinting or going out of logic in ch2, adding ch4's unlock item to spikeband's logic should prevent this.
